### PR TITLE
patches for 3.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ server/src/config/voices/*
 
 # Ant folders
 build/
-temp/
+temp/*
 
 #################
 ## Eclipse

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ server/src/config/voices/*
 
 # Ant folders
 build/
-temp/*
+temp/
 
 #################
 ## Eclipse

--- a/client/src/upstage/view/ChatField.as
+++ b/client/src/upstage/view/ChatField.as
@@ -336,12 +336,10 @@ function parseURLs(sMessage:String):String
 /**
  * @brief Create the URL for the message
  */
-function buildURL(sLink:String):String
-{
+function buildURL(sLink:String):String {
 	//if there is no http:// in the message, just www...
-	if (sLink.indexOf("http://") == -1)
-	{
-		//add http:// to the front of the message
+	trace(sLink);
+	if (sLink.indexOf("http://") == -1 && sLink.indexOf("https://") == -1){
 		sLink = "http://" + sLink;
 	}
 	//Create the URL and return it to parseURLs

--- a/client/src/upstage/view/ChatInput.as
+++ b/client/src/upstage/view/ChatInput.as
@@ -26,16 +26,13 @@ import upstage.util.Construct;
  * Chat Input view.
  *
  */
-class upstage.view.ChatInput
-{
+class upstage.view.ChatInput {
     private var tf           :TextField;
     private var history      :Array;
     private var historyIndex :Number = 0;
     private var historyNow   :String = ''; //current text.
 
-    function ChatInput(parent :MovieClip, canAct :Boolean, col :Number)// Added canAct - LK 17/10/07
-    {
-
+    function ChatInput(parent :MovieClip, canAct :Boolean, col :Number){
 		if (canAct){
         	// Chat input
         	this.tf =  Construct.formattedTextField(parent, 'chatInput', 
@@ -49,19 +46,15 @@ class upstage.view.ChatInput
                                                 Client.ANON_CHAT_INPUT_Y, Client.CHAT_INPUT_W, 
                                                 Client.CHAT_INPUT_H, 1, true);
 		}
-
         //this.tf.type= 'input';  
-        
         // AC (10/06/08) - Initial set to disable until stage loaded fully.
         this.setEnabled(false);
-        
         this.tf.border = true;
         this.tf.borderColor = Client.BORDER_COLOUR;
         this.tf.textColor = Client.TEXT_COLOUR;
         //Heath / Vibhu 09/08/2011 - Added to allow media managment system to correctly modify the colours of the chat fields
         this.tf.background = true;
         this.tf.backgroundColor = col;
-
         this.history = [];
         trace('ChatInput constructor done... ');
     }
@@ -69,8 +62,7 @@ class upstage.view.ChatInput
 	/**
 	 * @brief Allows or prevents text chat input.
 	 */
-	function setEnabled(enabled :Boolean) :Void
-	{
+	function setEnabled(enabled :Boolean):Void{
 		if (enabled) {
 			this.tf.type="input";
 			this.tf.selectable=true;
@@ -84,8 +76,7 @@ class upstage.view.ChatInput
     /**
      * @brief Put the application focus on the text field
      */
-    function focus() :Void
-    {
+    function focus():Void{
         Selection.setFocus(this.tf);
         var n :Number = Selection.getEndIndex();
         Selection.setSelection(n, n);

--- a/install.py
+++ b/install.py
@@ -36,53 +36,50 @@ appRootDir = os.path.abspath('.').replace(" ", "\ ")
 appServerDir = os.path.abspath('./server/src').replace(" ", "\ ")
 appClientDir = os.path.abspath('./client').replace(" ", "\ ")
 control_file_location = appRootDir+'/DEBIAN/control'
-system_calls = ['chmod +x /usr/local/upstage/*', 'chmod +x /etc/cron.weekly/upstage-backup', 'ln -s /usr/local/upstage/* /usr/local/bin/', 'ln -s /etc/cron.weekly/upstage-backup /usr/local/bin/']
-server_files = ['chownme.sh','img2swf.py','speaker.py','upstage-admin','upstage-admin.conf','upstage-backup','upstage-server']
+system_calls = ['chmod +x /usr/local/upstage/*',
+                'chmod +x /etc/cron.weekly/upstage-backup',
+                'ln -s /usr/local/upstage/* /usr/local/bin/',
+                'ln -s /etc/cron.weekly/upstage-backup /usr/local/bin/']
+server_files = ['chownme.sh','img2swf.py','speaker.py','upstage-admin',
+                'upstage-admin.conf','upstage-backup','upstage-server']
 
 """
 Replaces a line of text with another line of text in a file. Just a simple helper method.
 """
 def replaceAll(file,searchExp,replaceExp):
-	for line in fileinput.input(file, inplace=1):
-		if searchExp in line:
-			line = line.replace(searchExp,replaceExp)
-		sys.stdout.write(line)
+    for line in fileinput.input(file, inplace=1):
+	if searchExp in line:
+            line = line.replace(searchExp,replaceExp)
+	    sys.stdout.write(line)
 
 """
 Compiles the client, Actionscript 3 into swf file. The path to the compiler must be
 provided.
 """
 def compile_client(): #compiler_path):
-	print "Compiling Client..."
-	temp = appRootDir + '/client/src/temp'
-	os.system('mkdir ' + temp)
-
-	# using mtasc and swfmill - hard code options for now
-
-	mtasc = 'mtasc -swf ' + temp + '/classes.swf -frame 1 -header 320:200:31 -trace App.debug -version 8 -v -strict -msvc -wimp -cp ' + appClientDir + '/src App.as upstage/Client.as'
-	print mtasc
-	os.system(mtasc)
-
-	os.system('cp -r '+ appClientDir + '/src/font/*.ttf ' + temp)
-	os.system('cp -r '+ appClientDir + '/src/image/*.png ' + temp)
-
-	swfmill = 'swfmill -v simple ' + appClientDir + '/src/application.xml ' + appServerDir +'/html/swf/client.swf'
-	print swfmill
-	os.system(swfmill)
-
-	#os.system('rm -rf ' + temp)
-
-	# using flex - don't know if it still works
-
-	# current_path = os.path.abspath('')
-	# os.system('cp '+current_path+'/client/upstage/org/flex-config.xml '+current_path+'/')
-	# flex_config_path = current_path + '/flex-config.xml'
-	# print flex_config_path
-	# #replace expression
-	# replaceAll(flex_config_path,'<source-path></source-path>','\t<source-path><path-element>'+current_path+'/client/upstage/'+'</path-element></source-path>\n')
-	# os.system('cp '+flex_config_path +' '+ compiler_path+'/frameworks/')
-	# os.system(compiler_path+'/bin/mxmlc' +' '+current_path+'/client/upstage/org/main.mxml')
-	# file_util.copy_file(current_path+'/client/upstage/org/main.swf', current_path+'/html/swf/classes.swf')
+    print "Compiling Client..."
+    temp = appRootDir + '/client/src/temp'
+    os.system('mkdir ' + temp)
+    # using mtasc and swfmill - hard code options for now
+    mtasc = 'mtasc -swf ' + temp + '/classes.swf -frame 1 -header 320:200:31 -trace App.debug -version 8 -v -strict -msvc -wimp -cp ' + appClientDir + '/src App.as upstage/Client.as'
+    print mtasc
+    os.system(mtasc)
+    os.system('cp -r '+ appClientDir + '/src/font/*.ttf ' + temp)
+    os.system('cp -r '+ appClientDir + '/src/image/*.png ' + temp)
+    swfmill = 'swfmill -v simple ' + appClientDir + '/src/application.xml ' + appServerDir +'/html/swf/client.swf'
+    print swfmill
+    os.system(swfmill)
+    #os.system('rm -rf ' + temp)
+    # using flex - don't know if it still works
+    # current_path = os.path.abspath('')
+    # os.system('cp '+current_path+'/client/upstage/org/flex-config.xml '+current_path+'/')
+    # flex_config_path = current_path + '/flex-config.xml'
+    # print flex_config_path
+    # #replace expression
+    # replaceAll(flex_config_path,'<source-path></source-path>','\t<source-path><path-element>'+current_path+'/client/upstage/'+'</path-element></source-path>\n')
+    # os.system('cp '+flex_config_path +' '+ compiler_path+'/frameworks/')
+    # os.system(compiler_path+'/bin/mxmlc' +' '+current_path+'/client/upstage/org/main.mxml')
+    # file_util.copy_file(current_path+'/client/upstage/org/main.swf', current_path+'/html/swf/classes.swf')
 
 """
 Parses the control file to extract the user
@@ -140,89 +137,82 @@ def generate_deb(packagename):
 Cleans up etc.
 """
 def finalizeSetup():
-	print '\n'
-	print 'Finalizing Setup.'
-	print '\n'
-	for call in system_calls:
-		os.system(call)
-	print '***************************************************************'
-	print '\n'
-	print 'Thank you for choosing to use UpStage!'
-	print 'Visit upstage.org.nz for more information about UpStage'
-	print '\n'
-	print '***************************************************************'
-	print '\n'
-	print 'To Create a new server run as root: upstage-admin create'
-	print 'To Start a server run as root: upstage-admin start servername'
-	print 'To See if any servers are active run as root: upstage-admin ls\n'
-	print '			        		 AUT UpStage Team'
-	print '\n'
-	print '***************************************************************'
+    print '\n'
+    print 'Finalizing Setup.'
+    print '\n'
+    for call in system_calls:
+    	os.system(call)
+    print '***************************************************************'
+    print '\n'
+    print 'Thank you for choosing to use UpStage!'
+    print 'Visit upstage.org.nz for more information about UpStage'
+    print '\n'
+    print '***************************************************************'
+    print '\n'
+    print 'To Create a new server run as root: upstage-admin create'
+    print 'To Start a server run as root: upstage-admin start servername'
+    print 'To See if any servers are active run as root: upstage-admin ls\n'
+    print '			        		 AUT UpStage Team'
+    print '\n'
+    print '***************************************************************'
 
 """
 Copies files and folders to the installed paths
 """
 def copyFiles(location, noargs):
-	if(noargs):
-		if(os.path.exists(location+'/config')):
-			dir_util.copy_tree(location+'/config', baseDir+'upstage/DEFAULT/config/')
-			print 'Copying Directory: '+location+'/config' + ' -to- '+ baseDir+'upstage/DEFAULT/config/'
-		if(os.path.exists(location+'/html')):
-			dir_util.copy_tree(location+'/html', baseDir+'upstage/DEFAULT/html/')
-			print 'Copying Directory: '+location+'/html' + ' -to- '+ baseDir+'upstage/DEFAULT/html/'
-		if(os.path.exists(location+'/upstage'))	:
-			dir_util.copy_tree(location+'/upstage', serverDir+'upstage/upstage/')
-			print 'Copying Directory: '+location+'/upstage' + ' -to- '+ serverDir+'upstage/upstage/'
-		for file in server_files:
-			if(file == 'upstage-admin.conf'):
-				if(not os.path.exists(config_path+'upstage/')):
-					print 'Creating: '+config_path+'upstage/'
-					os.makedirs(config_path+'upstage/')
-				file_util.copy_file(location+'/'+file, config_path+'upstage/'+file)
-				print 'Copied: '+location+'/'+file+ ' -to- '+ config_path+'upstage/'+file
-			if(file == 'upstage-backup'):
-				file_util.copy_file(location+'/'+file, backup_location+file)
-				print 'copied: '+ location+'/'+file+' -to- '+ backup_location+file
-			shutil.copyfile(location+'/'+file, serverDir+'upstage/'+file)
-			print 'copied: '+ location+'/'+file+' -to- '+ serverDir+'upstage/'+file
-
+    if(noargs):
+        if(os.path.exists(location+'/config')):
+            dir_util.copy_tree(location+'/config', baseDir+'upstage/DEFAULT/config/')
+	    print 'Copying Directory: '+location+'/config' + ' -to- '+ baseDir+'upstage/DEFAULT/config/'
+	if(os.path.exists(location+'/html')):
+	    dir_util.copy_tree(location+'/html', baseDir+'upstage/DEFAULT/html/')
+	    print 'Copying Directory: '+location+'/html' + ' -to- '+ baseDir+'upstage/DEFAULT/html/'
+	if(os.path.exists(location+'/upstage'))	:
+	    dir_util.copy_tree(location+'/upstage', serverDir+'upstage/upstage/')
+	    print 'Copying Directory: '+location+'/upstage' + ' -to- '+ serverDir+'upstage/upstage/'
+	for file in server_files:
+	    if(file == 'upstage-admin.conf'):
+		if(not os.path.exists(config_path+'upstage/')):
+	            print 'Creating: '+config_path+'upstage/'
+		    os.makedirs(config_path+'upstage/')
+		    file_util.copy_file(location+'/'+file, config_path+'upstage/'+file)
+		    print 'Copied: '+location+'/'+file+ ' -to- '+ config_path+'upstage/'+file
+		if(file == 'upstage-backup'):
+		    file_util.copy_file(location+'/'+file, backup_location+file)
+		    print 'copied: '+ location+'/'+file+' -to- '+ backup_location+file
+		    shutil.copyfile(location+'/'+file, serverDir+'upstage/'+file)
+		    print 'copied: '+ location+'/'+file+' -to- '+ serverDir+'upstage/'+file                    
 
 """
-
 Execute the script.
-
 """
 if(len(sys.argv) >= 2):
-	if(sys.argv[1] == 'cc'):
-		# now compile using mtasc and swfmill
-		compile_client()
-
-		# if(sys.argv[2] == None):
-		# 	print "Compile client.."
-			# print "Usage: python install.py cc /path/to/flex/compiler/"
-		# else:
-		# 	# compile_client(sys.argv[2])
-		# 	# print 'Client compiled Sucessfully! You can now create a deb file or install from source using:'
-		# 	print 'To create a deb file: '
-		# 	print 'sudo python install.py deb'
-		# 	print 'To install from source: '
-		# 	print 'sudo python install.py'
-	elif(sys.argv[1] == 'deb' and len(sys.argv) > 2):
-		print "Changing permissions for install scripts."
-		os.system('chmod 755 '+appServerDir+'/DEBIAN/*')
-		generate_deb(sys.argv[2])
-	elif(sys.argv[1] == 'deb'):
-		print "Changing permissions for install scripts."
-		os.system('chmod 755 '+appServerDir+'/DEBIAN/*')
-		generate_deb('')# usage python install.py deb
-
-else:
+    if(sys.argv[1] == 'cc'):
+    # now compile using mtasc and swfmill
+        compile_client()
+    # if(sys.argv[2] == None):
+    # print "Compile client.."
+    # print "Usage: python install.py cc /path/to/flex/compiler/"
+    # else:
+    # compile_client(sys.argv[2])
+    # print 'Client compiled Sucessfully! You can now create a deb file or install from source using:'
+    # print 'To create a deb file: '
+    # print 'sudo python install.py deb'
+    # print 'To install from source: '
+    # print 'sudo python install.py'
+    elif(sys.argv[1] == 'deb' and len(sys.argv) > 2):
+	print "Changing permissions for install scripts."
+	os.system('chmod 755 '+appServerDir+'/DEBIAN/*')
+	generate_deb(sys.argv[2])
+    elif(sys.argv[1] == 'deb'):
+	print "Changing permissions for install scripts."
+	os.system('chmod 755 '+appServerDir+'/DEBIAN/*')
+	generate_deb('')# usage python install.py deb
+    else:
 	print "Removing .git files from current directory and all subdirectories..."
 	os.system('rm -rf `find . -type d -name .git`')
 	copyFiles(appServerDir, True)
 	finalizeSetup()
-
-
 #print "flex-config.xml created. Please copy the file to <flex compile location><frameworks>"
 
 		#<source-path><path-element>/home/heath/upstage/client/upstage/</path-element></source-path>

--- a/server/src/config/templates/master_b.inc
+++ b/server/src/config/templates/master_b.inc
@@ -1,6 +1,6 @@
 		</div>
 		<div id="footer">
-			<p>UpStage 3.4.2 (26/05/2015) <br> UpStage recommends the latest versions of the following browsers: Chrome (Windows & Mac OSX), Safari (Mac OSX) and Firefox (Ubuntu)</p>
+			<p>UpStage 3.4.3 (14/07/2015) <br> UpStage recommends the latest versions of the following browsers: Chrome (Windows & Mac OSX), Safari (Mac OSX) and Firefox (Ubuntu)</p>
 		</div>
 		<div id="status" style="display:none;">
 		</div>

--- a/server/src/upstage/config.py
+++ b/server/src/upstage/config.py
@@ -43,76 +43,76 @@ POLICY_FILE = "<?xml version=\"1.0\"?> \
 
 # AC (22.05.08) - Port for serving policy files
 POLICY_FILE_PORT = 3000
-SWF_PORT 	 = 7230
-WEB_PORT 	 = 8081
-LOG_FILE 	 = 'upstage.log'
-PID_FILE 	 = 'upstage.pid'
-BASE_DIR 	 = '.'
+SWF_PORT = 7230
+WEB_PORT = 8081
+LOG_FILE = 'upstage.log'
+PID_FILE = 'upstage.pid'
+BASE_DIR = '.'
 
 # Declare constants for directories
 ## @brief HTDOCS base html directory name
-HTDOCS     = 'html'
+HTDOCS = 'html'
 CONFIG_DIR = 'config'
 
 #URL paths for various bits. #
 #XXX some of these relate to stuff in web.py
 
-AUDIO_PATH     = 'audio/'   # PQ & EB: 13/10/07 - Used solely for deleting audio
-SWF_URL        = '/swf/'
-MEDIA_URL      = '/media/'
-OLD_MEDIA_URL  = '/oldmedia/'
+AUDIO_PATH = 'audio/'   # PQ & EB: 13/10/07 - Used solely for deleting audio
+SWF_URL = '/swf/'
+MEDIA_URL = '/media/'
+OLD_MEDIA_URL = '/oldmedia/'
 THUMBNAILS_URL = '/media/thumb/'
-SPEECH_URL     = '/speech/'
+SPEECH_URL = '/speech/'
 # PQ & EB: Added AUDIO_URL - 17.9.07 & PQ & EB: Edited 13/10/07
 AUDIO_URL = MEDIA_URL + AUDIO_PATH
 #MISSING_THUMB_URL = '/missing.png'
 #Lisa 21/08/2013 - removed video avatar code
-MISSING_THUMB_URL  = '/image/icon/icon-warning-sign.png'
+MISSING_THUMB_URL = '/image/icon/icon-warning-sign.png'
 MISSING_THUMB_ICON = 'icon-warning-sign'
 
-MEDIA_SUBURL     = MEDIA_URL.strip('/')
+MEDIA_SUBURL = MEDIA_URL.strip('/')
 OLD_MEDIA_SUBURL = OLD_MEDIA_URL.strip('/')
-SWF_SUBURL       = SWF_URL.strip('/')
-SPEECH_SUBURL    = SPEECH_URL.strip('/')
-AUDIO_SUBURL     = AUDIO_URL.strip('/') #PQ & EB: Added 17.9.07
+SWF_SUBURL  = SWF_URL.strip('/')
+SPEECH_SUBURL = SPEECH_URL.strip('/')
+AUDIO_SUBURL = AUDIO_URL.strip('/') #PQ & EB: Added 17.9.07
 
 # PQ & EB Added 13.10.07
 # Paths to music and sfx thumbnail images for the workshop to display
 MUSIC_ICON_IMAGE_URL = '/image/icon/icon-music.png'
-SFX_ICON_IMAGE_URL   = '/image/icon/icon-bullhorn.png'
+SFX_ICON_IMAGE_URL = '/image/icon/icon-bullhorn.png'
 
 # icon styles for music and sfx thumbnails
 MUSIC_ICON = 'icon-music' #Martins
-SFX_ICON   = 'icon-bullhorn' #Martins
+SFX_ICON = 'icon-bullhorn' #Martins
 
 # file system paths
 # these relate to the above url paths
-MEDIA_DIR      = _join(HTDOCS, MEDIA_SUBURL)
-OLD_MEDIA_DIR  = _join(HTDOCS, OLD_MEDIA_SUBURL)
+MEDIA_DIR = _join(HTDOCS, MEDIA_SUBURL)
+OLD_MEDIA_DIR = _join(HTDOCS, OLD_MEDIA_SUBURL)
 THUMBNAILS_DIR = _join(HTDOCS, MEDIA_SUBURL, 'thumb')
 
 #Lisa 21/08/2013 - removed video avatar code
-SWF_DIR      = _join(HTDOCS, SWF_SUBURL)
-ADMIN_DIR    = _join(HTDOCS, 'admin')
-PLAYER_DIR   = _join(HTDOCS, 'admin', 'player')
-SPEECH_DIR   = _join(HTDOCS, SPEECH_SUBURL)
-AUDIO_DIR    = _join(HTDOCS, AUDIO_SUBURL)
+SWF_DIR = _join(HTDOCS, SWF_SUBURL)
+ADMIN_DIR = _join(HTDOCS, 'admin')
+PLAYER_DIR = _join(HTDOCS, 'admin', 'player')
+SPEECH_DIR = _join(HTDOCS, SPEECH_SUBURL)
+AUDIO_DIR = _join(HTDOCS, AUDIO_SUBURL)
 TEMPLATE_DIR = _join(CONFIG_DIR, 'templates')
-STAGE_DIR    = _join(CONFIG_DIR, 'stages')
+STAGE_DIR = _join(CONFIG_DIR, 'stages')
 
 #XML config files
-PLAYERS_XML   = _join(CONFIG_DIR, 'players.xml')
-STAGES_XML    = _join(CONFIG_DIR, 'stages.xml')
-AVATARS_XML   = _join(CONFIG_DIR, 'avatars.xml')
-PROPS_XML     = _join(CONFIG_DIR, 'props.xml')
+PLAYERS_XML = _join(CONFIG_DIR, 'players.xml')
+STAGES_XML = _join(CONFIG_DIR, 'stages.xml')
+AVATARS_XML = _join(CONFIG_DIR, 'avatars.xml')
+PROPS_XML = _join(CONFIG_DIR, 'props.xml')
 BACKDROPS_XML = _join(CONFIG_DIR, 'backdrops.xml')
-AUDIOS_XML    = _join(CONFIG_DIR, 'audios.xml') # PQ & EB: 17.9.07
+AUDIOS_XML = _join(CONFIG_DIR, 'audios.xml') # PQ & EB: 17.9.07
 
 VOICE_SCRIPT_DIR = _join(CONFIG_DIR, 'voices')
 
 #should deleted media be saved in case it is wanted later?
 #(will be saved in OLD_MEDIA_DIR, abouve
-SAVE_DELETED_MEDIA=True
+SAVE_DELETED_MEDIA = True
 
 # how many drawing layers (has to match client, where UI is the restraint)
 DRAW_LAYERS = 5
@@ -136,7 +136,7 @@ UTTERANCE_WRAP = 999999
 
 #thing ids need to have a 'zero' which is guaranteed not to be any thing's id
 THING_NULL_ID = 0
-THING_MIN_ID  = 1
+THING_MIN_ID = 1
 
 LOG_ROTATE_SIZE = 1024 * 1024
 
@@ -160,9 +160,9 @@ SESSION_LIFETIME = 12*3600
 ## @brief NUL constant - you really don't want to change this!
 NUL=chr(0)
 
-CHECK_THUMB_SANITY=False
+CHECK_THUMB_SANITY = False
 
-REGENERATE_VOICE_SCRIPTS=True
+REGENERATE_VOICE_SCRIPTS = True
 
 """ Alan (13/09/07) ==> Constants used for upload size limits """
 ADMIN_SIZE_LIMIT = 1000000

--- a/server/src/upstage/config.py
+++ b/server/src/upstage/config.py
@@ -33,42 +33,41 @@ Changelog:
 
 from os.path import join as _join
 
-#VERBOSE = True
-VERBOSE = False
+#VERBOSE    = True
+VERBOSE	    = False
 
 POLICY_FILE = "<?xml version=\"1.0\"?> \
                <cross-domain-policy> \
-                 <allow-access-from domain=\"*\" to-ports=\"*\" /> \
+               <allow-access-from domain=\"*\" to-ports=\"*\" /> \
                </cross-domain-policy>"
 
 # AC (22.05.08) - Port for serving policy files
 POLICY_FILE_PORT = 3000
-SWF_PORT = 7230
-WEB_PORT = 8081
-LOG_FILE = 'upstage.log'
-PID_FILE = 'upstage.pid'
-BASE_DIR = '.'
+SWF_PORT 	 = 7230
+WEB_PORT 	 = 8081
+LOG_FILE 	 = 'upstage.log'
+PID_FILE 	 = 'upstage.pid'
+BASE_DIR 	 = '.'
 
 # Declare constants for directories
 ## @brief HTDOCS base html directory name
-HTDOCS       =  'html'
-CONFIG_DIR   =  'config'
+HTDOCS     = 'html'
+CONFIG_DIR = 'config'
 
 #URL paths for various bits. #
 #XXX some of these relate to stuff in web.py
 
-AUDIO_PATH =          'audio/'   # PQ & EB: 13/10/07 - Used solely for deleting audio
-
-SWF_URL  =           '/swf/'
-MEDIA_URL =          '/media/'
-OLD_MEDIA_URL =      '/oldmedia/'
-THUMBNAILS_URL =     '/media/thumb/'
-SPEECH_URL =         '/speech/'
+AUDIO_PATH     = 'audio/'   # PQ & EB: 13/10/07 - Used solely for deleting audio
+SWF_URL        = '/swf/'
+MEDIA_URL      = '/media/'
+OLD_MEDIA_URL  = '/oldmedia/'
+THUMBNAILS_URL = '/media/thumb/'
+SPEECH_URL     = '/speech/'
 # PQ & EB: Added AUDIO_URL - 17.9.07 & PQ & EB: Edited 13/10/07
-AUDIO_URL =          MEDIA_URL + AUDIO_PATH
+AUDIO_URL = MEDIA_URL + AUDIO_PATH
 #MISSING_THUMB_URL = '/missing.png'
 #Lisa 21/08/2013 - removed video avatar code
-MISSING_THUMB_URL =  '/image/icon/icon-warning-sign.png'
+MISSING_THUMB_URL  = '/image/icon/icon-warning-sign.png'
 MISSING_THUMB_ICON = 'icon-warning-sign'
 
 MEDIA_SUBURL     = MEDIA_URL.strip('/')
@@ -79,35 +78,33 @@ AUDIO_SUBURL     = AUDIO_URL.strip('/') #PQ & EB: Added 17.9.07
 
 # PQ & EB Added 13.10.07
 # Paths to music and sfx thumbnail images for the workshop to display
-MUSIC_ICON_IMAGE_URL    = '/image/icon/icon-music.png'
-SFX_ICON_IMAGE_URL      = '/image/icon/icon-bullhorn.png'
+MUSIC_ICON_IMAGE_URL = '/image/icon/icon-music.png'
+SFX_ICON_IMAGE_URL   = '/image/icon/icon-bullhorn.png'
 
 # icon styles for music and sfx thumbnails
-MUSIC_ICON	= 'icon-music' #Martins
-SFX_ICON	= 'icon-bullhorn' #Martins
+MUSIC_ICON = 'icon-music' #Martins
+SFX_ICON   = 'icon-bullhorn' #Martins
 
 # file system paths
 # these relate to the above url paths
-MEDIA_DIR        =  _join(HTDOCS, MEDIA_SUBURL)
-OLD_MEDIA_DIR    =  _join(HTDOCS, OLD_MEDIA_SUBURL)
-THUMBNAILS_DIR   =  _join(HTDOCS, MEDIA_SUBURL, 'thumb')
+MEDIA_DIR      = _join(HTDOCS, MEDIA_SUBURL)
+OLD_MEDIA_DIR  = _join(HTDOCS, OLD_MEDIA_SUBURL)
+THUMBNAILS_DIR = _join(HTDOCS, MEDIA_SUBURL, 'thumb')
 
 #Lisa 21/08/2013 - removed video avatar code
-SWF_DIR          =  _join(HTDOCS, SWF_SUBURL)
-
-ADMIN_DIR        =  _join(HTDOCS, 'admin')
-PLAYER_DIR     =  _join(HTDOCS, 'admin', 'player')
-SPEECH_DIR       =  _join(HTDOCS, SPEECH_SUBURL)
-AUDIO_DIR        =  _join(HTDOCS, AUDIO_SUBURL)
-
-TEMPLATE_DIR =    _join(CONFIG_DIR, 'templates')
-STAGE_DIR =       _join(CONFIG_DIR, 'stages')
+SWF_DIR      = _join(HTDOCS, SWF_SUBURL)
+ADMIN_DIR    = _join(HTDOCS, 'admin')
+PLAYER_DIR   = _join(HTDOCS, 'admin', 'player')
+SPEECH_DIR   = _join(HTDOCS, SPEECH_SUBURL)
+AUDIO_DIR    = _join(HTDOCS, AUDIO_SUBURL)
+TEMPLATE_DIR = _join(CONFIG_DIR, 'templates')
+STAGE_DIR    = _join(CONFIG_DIR, 'stages')
 
 #XML config files
-PLAYERS_XML =   _join(CONFIG_DIR, 'players.xml')
-STAGES_XML  =   _join(CONFIG_DIR, 'stages.xml')
-AVATARS_XML =   _join(CONFIG_DIR, 'avatars.xml')
-PROPS_XML   =   _join(CONFIG_DIR, 'props.xml')
+PLAYERS_XML   = _join(CONFIG_DIR, 'players.xml')
+STAGES_XML    = _join(CONFIG_DIR, 'stages.xml')
+AVATARS_XML   = _join(CONFIG_DIR, 'avatars.xml')
+PROPS_XML     = _join(CONFIG_DIR, 'props.xml')
 BACKDROPS_XML = _join(CONFIG_DIR, 'backdrops.xml')
 AUDIOS_XML    = _join(CONFIG_DIR, 'audios.xml') # PQ & EB: 17.9.07
 
@@ -139,7 +136,7 @@ UTTERANCE_WRAP = 999999
 
 #thing ids need to have a 'zero' which is guaranteed not to be any thing's id
 THING_NULL_ID = 0
-THING_MIN_ID = 1
+THING_MIN_ID  = 1
 
 LOG_ROTATE_SIZE = 1024 * 1024
 
@@ -188,44 +185,24 @@ _rsynth_lame = "| timeout 15 lame -S -x -m m -r -s 11.025 --preset phone - "
 _fest = " - -o -  2>>%s " % SPEECH_LOG + _fest_lame % 16
 _fest11 = " - -o -  2>>%s " % SPEECH_LOG + _fest_lame % 11.025
 
-
 ## @brief VOICES a list of the available voices
 VOICES = {
           #festival/mbrola:
-          'default': ("| timeout 15 text2wave -eval '(voice_us1_mbrola)' -otype raw", 
-                      _fest),          
-          'roger': ("| timeout 15 text2wave -eval '(voice_en1_mbrola)' -otype raw", 
-                    _fest),
-          'bud': ("| timeout 15 text2wave -eval '(voice_us2_mbrola)' -otype raw", 
-                  _fest),
-          'randy': ("| timeout 15 text2wave -eval '(voice_us3_mbrola)' -otype raw", 
-                  _fest),
+          'default': ("| timeout 15 text2wave -eval '(voice_us1_mbrola)' -otype raw", _fest),          
+          'roger': ("| timeout 15 text2wave -eval '(voice_en1_mbrola)' -otype raw", _fest),
+          'bud': ("| timeout 15 text2wave -eval '(voice_us2_mbrola)' -otype raw", _fest),
+          'randy': ("| timeout 15 text2wave -eval '(voice_us3_mbrola)' -otype raw", _fest),
           
           #festival/festival
-          'kal': ("| timeout 15 text2wave -eval '(voice_kal_diphone)' -otype raw", 
-                  _fest),
-          'ked': ("| timeout 15 text2wave -eval '(voice_ked_diphone)' -otype raw", 
-                  _fest),
-          'rab': ("| timeout 15 text2wave -eval '(voice_rab_diphone)' -otype raw", 
-                  _fest),
-          'don': ("| timeout 15 text2wave -eval '(voice_don_diphone)' -otype raw", 
-                  _fest11
-                  ),
+          'kal': ("| timeout 15 text2wave -eval '(voice_kal_diphone)' -otype raw", _fest),
+          'ked': ("| timeout 15 text2wave -eval '(voice_ked_diphone)' -otype raw", _fest),
+          'rab': ("| timeout 15 text2wave -eval '(voice_rab_diphone)' -otype raw", _fest),
+          'don': ("| timeout 15 text2wave -eval '(voice_don_diphone)' -otype raw", _fest11),
           
           #rsynth:
-          'slow': ("| timeout 15 rsynth-say -a  -l -x 1200 -S 3  -  2>>./speech.log ",
-                   _rsynth_lame
-                  ),
-          'high': ("| timeout 15 rsynth-say -a  -l -x 2800 -S 1.4  -  2>>./speech.log ",
-                   _rsynth_lame
-                  ),
-          'crunchy' :("| timeout 15 rsynth-say -a  -l -x 1000 -f 16 -F 700 -t 20  -  2>>./speech.log ",
-                   _rsynth_lame
-                  ), 
-         }         
-
-
+          'slow': ("| timeout 15 rsynth-say -a  -l -x 1200 -S 3  -  2>>./speech.log ", _rsynth_lame),
+          'high': ("| timeout 15 rsynth-say -a  -l -x 2800 -S 1.4  -  2>>./speech.log ", _rsynth_lame),
+          'crunchy' :("| timeout 15 rsynth-say -a  -l -x 1000 -f 16 -F 700 -t 20  -  2>>./speech.log ", _rsynth_lame), 
+         }
 del _fest, _rsynth_lame, _fest11, _fest_lame
-
-
 """New Added lines end"""


### PR DESCRIPTION
I continued my previous work regarding to server installation processes and requirement enhancement for the current implementation.

Completed updated requirement for clickable link in the Chat Box.
When stage users enter http:// or https:// as the header, chat history shall not add extra http:// or https://
From my observation, The entire Chat Field is implemented as a vector (in Java comparable). All the text are updated each time. In my opinion, this seems less efficient. All the related work are in ChatField and ChatInput classes.

Regarding to Server Installation part, If we will remove libgdbmg rsynth (both packages are obsolete). I have not figured out the purpose of libgdbmg yet (seems DB related).
When we remove rsynth, we probably need to modify the code in install.py (where tts resources are assigned); however, this is my initial guess. 
